### PR TITLE
Added missing parenthesis to displayFormAtt() function and removed obsolete dot

### DIFF
--- a/comment-attachment-init.php
+++ b/comment-attachment-init.php
@@ -685,7 +685,7 @@ if (!class_exists('wpCommentAttachment')){
         {
             $required = ATT_REQ ? ' <span class="required">*</span>' : '';
             echo '<p class="comment-form-url comment-form-attachment">'.
-                '<label for="attachment">' . ATT_TITLE . $required .'<small class="attachmentRules">&nbsp;&nbsp;('.__('Allowed file types','comment-attachment').': <strong>'. $this->displayAllowedFileTypes() .'</strong>, '.__('maximum file size','comment-attachment').': <strong>'. ATT_MAX .'MB.</strong></small></label>'.
+                '<label for="attachment">' . ATT_TITLE . $required .'<small class="attachmentRules">&nbsp;&nbsp;('.__('Allowed file types','comment-attachment').': <strong>'. $this->displayAllowedFileTypes() .'</strong>, '.__('maximum file size','comment-attachment').': <strong>'. ATT_MAX .'MB</strong>)</small></label>'.
                 '</p>'.
                 '<p class="comment-form-url comment-form-attachment"><input id="attachment" name="attachment" type="file" /></p>';
         }


### PR DESCRIPTION
This is my first pull request ever, so I hope everything is fine. I added a missing parenthesis to the allowed file type options and removed the dot right before that parenthesis.
